### PR TITLE
Prevent error-prone of duplicating API objects, which could result to rate-limit errors

### DIFF
--- a/src/main/kotlin/kmtt/impl/AbstractKmtt.kt
+++ b/src/main/kotlin/kmtt/impl/AbstractKmtt.kt
@@ -12,7 +12,7 @@ import java.time.Duration
 /**
  * Abstract class that provides [IHttpClient] implementation with rate limit
  */
-abstract class AbstractKmtt(
+internal abstract class AbstractKmtt(
     limitForPeriod: Int = 3,
     limitRefreshPeriod: Duration = Duration.ofSeconds(1),
     timeoutDuration: Duration = Duration.ofHours(100)

--- a/src/main/kotlin/kmtt/impl/AuthKmtt.kt
+++ b/src/main/kotlin/kmtt/impl/AuthKmtt.kt
@@ -6,7 +6,7 @@ import kmtt.api.entry.AuthEntryAPI
 import kmtt.api.entry.IAuthEntryAPI
 import kmtt.models.enums.Website
 
-class AuthKmtt(val website: Website, val token: String): AbstractKmtt(), IAuthKmtt {
+internal class AuthKmtt(val website: Website, val token: String): AbstractKmtt(), IAuthKmtt {
     override val entry: IAuthEntryAPI = AuthEntryAPI(client, website, token)
     override val comments: IAuthCommentAPI = AuthCommentAPI(client, website, token)
 }

--- a/src/main/kotlin/kmtt/impl/Builders.kt
+++ b/src/main/kotlin/kmtt/impl/Builders.kt
@@ -26,7 +26,7 @@ fun authKmtt(
         client = authClients[website to token]!!
     } else {
         client = AuthKmtt(website, token)
-        publicClients[website] = client
+        authClients[website to token] = client
     }
 
     return client

--- a/src/main/kotlin/kmtt/impl/Builders.kt
+++ b/src/main/kotlin/kmtt/impl/Builders.kt
@@ -1,0 +1,36 @@
+package kmtt.impl
+
+import kmtt.models.enums.Website
+
+/**
+ * Create object of [authenticated API][IAuthKmtt]
+ */
+fun authKmtt(website: Website, token: String): IAuthKmtt = AuthKmtt(website, token)
+
+internal val publicClients = mutableMapOf<Website, IPublicKmtt>()
+
+/**
+ * Create object of [public API][IPublicKmtt]
+ *
+ * @param preventClientDuplication
+ *
+ * Duplication of Public API objects can lead to rate-limit error.
+ * By this parameter you can, instead of creating new objects, get already created objects.
+ *
+ * Default: **true**
+ */
+fun publicKmtt(
+    website: Website,
+    preventClientDuplication: Boolean = true,
+): IPublicKmtt {
+    val client: IPublicKmtt
+
+    if (preventClientDuplication && publicClients.containsKey(website)) {
+        client = publicClients[website]!!
+    } else {
+        client = PublicKmtt(website)
+        publicClients[website] = client
+    }
+
+    return client
+}

--- a/src/main/kotlin/kmtt/impl/Builders.kt
+++ b/src/main/kotlin/kmtt/impl/Builders.kt
@@ -1,13 +1,14 @@
 package kmtt.impl
 
 import kmtt.models.enums.Website
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Create object of [authenticated API][IAuthKmtt]
  */
 fun authKmtt(website: Website, token: String): IAuthKmtt = AuthKmtt(website, token)
 
-internal val publicClients = mutableMapOf<Website, IPublicKmtt>()
+internal val publicClients: MutableMap<Website, IPublicKmtt> = ConcurrentHashMap<Website, IPublicKmtt>()
 
 /**
  * Create object of [public API][IPublicKmtt]

--- a/src/main/kotlin/kmtt/impl/Builders.kt
+++ b/src/main/kotlin/kmtt/impl/Builders.kt
@@ -20,6 +20,7 @@ internal val publicClients: MutableMap<Website, IPublicKmtt> = ConcurrentHashMap
  *
  * Default: **true**
  */
+@Synchronized
 fun publicKmtt(
     website: Website,
     preventClientDuplication: Boolean = true,

--- a/src/main/kotlin/kmtt/impl/PublicKmtt.kt
+++ b/src/main/kotlin/kmtt/impl/PublicKmtt.kt
@@ -6,7 +6,7 @@ import kmtt.api.entry.IPublicEntryAPI
 import kmtt.api.entry.PublicEntryAPI
 import kmtt.models.enums.Website
 
-class PublicKmtt(val website: Website): AbstractKmtt(), IPublicKmtt {
+internal class PublicKmtt(val website: Website): AbstractKmtt(), IPublicKmtt {
     override val entry: IPublicEntryAPI = PublicEntryAPI(client, website)
     override val comments: IPublicCommentAPI = PublicCommentAPI(client, website)
 }

--- a/src/main/kotlin/kmtt/ktor/HttpClientAdapter.kt
+++ b/src/main/kotlin/kmtt/ktor/HttpClientAdapter.kt
@@ -11,7 +11,7 @@ import io.ktor.util.*
 import java.util.*
 import kotlin.coroutines.CoroutineContext
 
-class HttpClientAdapter(override val client: HttpClient, rateLimitConfig: RateLimiterConfig) : IHttpClient {
+internal class HttpClientAdapter(override val client: HttpClient, rateLimitConfig: RateLimiterConfig) : IHttpClient {
     private val rateLimitID = UUID.randomUUID().toString()
     private val rateLimiterRegistry = RateLimiterRegistry.of(rateLimitConfig)
     override val rateLimiter: RateLimiter = rateLimiterRegistry.rateLimiter(rateLimitID)

--- a/src/main/kotlin/kmtt/ktor/IHttpClient.kt
+++ b/src/main/kotlin/kmtt/ktor/IHttpClient.kt
@@ -40,7 +40,6 @@ internal interface IHttpClient : CoroutineScope, Closeable {
 internal suspend inline fun <reified T> IHttpClient.request(crossinline block: HttpRequestBuilder.() -> Unit): T {
     try {
         return rateLimiter.executeSuspendFunction {
-            println("suspend function in rate limit - executed")
             client.request(block)
         }
     } catch (ex: ClientRequestException) {

--- a/src/main/kotlin/kmtt/ktor/IHttpClient.kt
+++ b/src/main/kotlin/kmtt/ktor/IHttpClient.kt
@@ -18,7 +18,7 @@ import java.io.Closeable
 /**
  * Extracted interface of [Ktor client][HttpClient]. Can be used for implementing extended versions of client
  */
-interface IHttpClient : CoroutineScope, Closeable {
+internal interface IHttpClient : CoroutineScope, Closeable {
     val client: HttpClient
     val rateLimiter: RateLimiter
 
@@ -37,7 +37,7 @@ interface IHttpClient : CoroutineScope, Closeable {
 /**
  * Builder for creating http requests
  */
-suspend inline fun <reified T> IHttpClient.request(crossinline block: HttpRequestBuilder.() -> Unit): T {
+internal suspend inline fun <reified T> IHttpClient.request(crossinline block: HttpRequestBuilder.() -> Unit): T {
     try {
         return rateLimiter.executeSuspendFunction {
             println("suspend function in rate limit - executed")

--- a/src/main/kotlin/kmtt/ktor/IHttpClient.kt
+++ b/src/main/kotlin/kmtt/ktor/IHttpClient.kt
@@ -40,6 +40,7 @@ interface IHttpClient : CoroutineScope, Closeable {
 suspend inline fun <reified T> IHttpClient.request(crossinline block: HttpRequestBuilder.() -> Unit): T {
     try {
         return rateLimiter.executeSuspendFunction {
+            println("suspend function in rate limit - executed")
             client.request(block)
         }
     } catch (ex: ClientRequestException) {

--- a/src/test/kotlin/kmtt/common/Shared.kt
+++ b/src/test/kotlin/kmtt/common/Shared.kt
@@ -10,7 +10,7 @@ import kmtt.models.enums.Website
 import kmtt.models.EntryComment
 import java.time.Duration
 
-object Shared {
+internal object Shared {
     val httpClient: IHttpClient
     val website: Website = Website.DTF
     val token: String = System.getenv("TEST_DTF_TOKEN")


### PR DESCRIPTION
Before, you could create multiple API objects and get around of rate-limiting, because rate-limiting isn't global, and it was working only with the object where `rate-limiter` was created.

To fix this problem, I hide all constructors of API implementations, moved creation logic to `Builders` and add _"prevent object duplication"_ feature: If a user creates multiple objects with the same arguments, then the first time builder will create the object as usual and save it to cache. On next calls, `Builder` instead of creating the same object twice or more, will return value from cache.

![idea64_OdkDPcMuRE](https://user-images.githubusercontent.com/47672780/161982549-78b315da-5aae-4fe8-8db2-d05034696937.png)

> Builder functions are synchronized and works well with coroutines


Yes, I could create a global `rate-limit` registry, but it would take more changes in code, then `Builder` functionality. Also, `Builder` pattern gives more future options for customizing object creation + you can add Kotlin DSL in `Builder` 